### PR TITLE
vectors useable now

### DIFF
--- a/actsafe/actsafe/actsafe.py
+++ b/actsafe/actsafe/actsafe.py
@@ -263,7 +263,7 @@ def _prepare_features(batch: TrajectoryData) -> tuple[rssm.Features, jax.Array]:
 
 
 def preprocess(input: np.ndarray) -> np.ndarray:
-    if input.ndim == 4:
+    if input.ndim >= 4:
         return input / 255.0 - 0.5
     else:
         return input

--- a/actsafe/actsafe/replay_buffer.py
+++ b/actsafe/actsafe/replay_buffer.py
@@ -20,7 +20,12 @@ class ReplayBuffer:
     ):
         self.episode_id = 0
         self.dtype = np.float32
-        self.obs_dtype = np.uint8
+
+        if len(observation_shape)>2:#img
+            self.obs_dtype = np.uint8
+        else:# vector
+            self.obs_dtype = np.float32
+
         self.observation = np.zeros(
             (
                 capacity,


### PR DESCRIPTION
Images sometimes have dim 4 or 5, so preprocessing doesn't always work otherwise. 
Vector-envs usually have continuous values not integers.